### PR TITLE
Add CircleMarker and clean-up Circle

### DIFF
--- a/src/main/java/org/peimari/gleaflet/client/Circle.java
+++ b/src/main/java/org/peimari/gleaflet/client/Circle.java
@@ -5,7 +5,7 @@ public class Circle extends AbstractPath {
 	
 	protected Circle() {}
 	
-	public static native Circle create(LatLng latlng, Double radius, PathOptions circleOptions) 
+	public static native Circle create(LatLng latlng, Double radius, CircleOptions circleOptions)
 	/*-{
 		return new $wnd.L.Circle(latlng, radius, circleOptions);
 	}-*/;

--- a/src/main/java/org/peimari/gleaflet/client/CircleMarker.java
+++ b/src/main/java/org/peimari/gleaflet/client/CircleMarker.java
@@ -1,0 +1,13 @@
+package org.peimari.gleaflet.client;
+
+
+public class CircleMarker extends Circle {
+
+	protected CircleMarker() {}
+
+	public static native CircleMarker create(LatLng latlng, CircleMarkerOptions circleMarkerOptions)
+	/*-{
+		return new $wnd.L.CircleMarker(latlng, circleMarkerOptions);
+	}-*/;
+
+}

--- a/src/main/java/org/peimari/gleaflet/client/CircleMarkerOptions.java
+++ b/src/main/java/org/peimari/gleaflet/client/CircleMarkerOptions.java
@@ -1,0 +1,17 @@
+package org.peimari.gleaflet.client;
+
+
+public class CircleMarkerOptions extends CircleOptions {
+
+	protected CircleMarkerOptions() {}
+
+	public static native CircleMarkerOptions create()
+	/*-{
+		return {};
+	}-*/;
+
+	public native final void setRadius(Double radius)
+	/*-{
+		this.radius = radius;
+	}-*/;
+}

--- a/src/main/java/org/peimari/gleaflet/client/CircleOptions.java
+++ b/src/main/java/org/peimari/gleaflet/client/CircleOptions.java
@@ -1,23 +1,12 @@
 package org.peimari.gleaflet.client;
 
-import com.google.gwt.core.client.JavaScriptObject;
 
-public class CircleOptions extends JavaScriptObject {
-	
+public class CircleOptions extends PathOptions {
+
 	protected CircleOptions() {}
-	
-	public static native CircleOptions create(double latitude, double longitude) 
-	/*-{
-		return new $wnd.L.LatLng(latitude, longitude);
-	}-*/;
-	
-	public native final Double getLatitude() 
-	/*-{
-		this.lat;
-	}-*/;
 
-	public native final Double getLongitude() 
+	public static native CircleOptions create()
 	/*-{
-		this.lng;
+		return {};
 	}-*/;
 }


### PR DESCRIPTION
Wasn't sure whether to make it inherit from `Circle` but since `Circle` hast double radius and radius in constructor but  `CircleMarker` has integer radius and receives it in options instead of constructor, I decided not to inherit.
