### PR TITLE
remove slash from markers path. This leads to doubleslashes within URL

### DIFF
--- a/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
+++ b/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
@@ -25,7 +25,7 @@ public class LeafletResourceInjector {
 	}
 
 	protected String getDefaultMarkerDirectory() {
-		return GWT.getModuleBaseURL() + "markers/";
+		return GWT.getModuleBaseURL() + "markers";
 	}
 
 	protected native static void setDefaultMarkerIconPath(String path) 


### PR DESCRIPTION
The doubleslash causes a problem if the compiled widgetset is inside a jar
