### PR TITLE
Added method to set a generic custom option in TileLayerOptions

### DIFF
--- a/src/main/java/org/peimari/gleaflet/client/TileLayerOptions.java
+++ b/src/main/java/org/peimari/gleaflet/client/TileLayerOptions.java
@@ -69,5 +69,10 @@ public class TileLayerOptions extends JavaScriptObject {
 	/*-{
 		this.noWrap = noWrap;
 	}-*/;
+
+	public native final void setCustomOption(String optionName, String optionValue)
+	/*-{
+		this[optionName] = optionValue;
+	}-*/;
 	
 }


### PR DESCRIPTION
This pull request adds the ability to set a custom option for tile layers, specifying the option name and value (as a string)
