### PR TITLE
Fix Popup.addCloseListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.2</version>
+            <optional>true</optional>
         </dependency>
 
 

--- a/src/main/java/org/peimari/gleaflet/client/Popup.java
+++ b/src/main/java/org/peimari/gleaflet/client/Popup.java
@@ -45,7 +45,7 @@ public class Popup extends JavaScriptObject {
      var fn = $entry(function(e) {
      	listener.@org.peimari.gleaflet.client.PopupClosedListener::onClosed(Lorg/peimari/gleaflet/client/Event;)(e);
      });
-     fn.prototype['gname'] = "close";
+     fn.prototype['gname'] = "remove";
      this.on(fn.prototype['gname'], fn);
      return fn;
      }-*/;


### PR DESCRIPTION
There's no `close` event in Leaflet, but there is `popupclose`. Also there's a problem that `popupclose` is not fired against standalone popup layer, for which I've proposed a fix in https://github.com/Leaflet/Leaflet/pull/3812 and manually merged it into g-leaflet for now.

As a bonus, #19 is fixed here because I'm lazy to create separate branch