### PR TITLE
Support for the definition of new Crs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <!-- POM file generated with GWT webAppCreator -->
     <modelVersion>4.0.0</modelVersion>
 
-    <version>0.4.11</version>
+    <version>0.4.12-SNAPSHOT</version>
     <groupId>org.peimari</groupId>
     <artifactId>g-leaflet</artifactId>
     <packaging>jar</packaging>
@@ -14,7 +14,7 @@
         <url>git://github.com/mstahv/g-leaflet.git</url>
         <connection>scm:git:git://github.com/mstahv/g-leaflet.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:/mstahv/g-leaflet.git</developerConnection>
-      <tag>g-leaflet-0.4.11</tag>
+      <tag>g-leaflet-0.4.12-SNAPSHOT</tag>
   </scm>
 
     <dependencies>

--- a/src/main/java/org/peimari/gleaflet/client/Crs.java
+++ b/src/main/java/org/peimari/gleaflet/client/Crs.java
@@ -33,4 +33,14 @@ public class Crs extends JavaScriptObject {
 	/*-{
 		return $wnd.L.CRS[name];
 	}-*/;
+
+	public static native final Crs add(String name, String projection, double a, double b, double c, double d)
+	/*-{
+            $wnd.L.CRS[name] = $wnd.L.extend({}, $wnd.L.CRS.Simple, {
+                code: name,
+		projection: $wnd.L.Projection[projection],
+                transformation: new $wnd.L.Transformation(a, b, c, d)
+            });
+            return $wnd.L.CRS[name];
+        }-*/;
 }

--- a/src/main/java/org/peimari/gleaflet/client/Crs.java
+++ b/src/main/java/org/peimari/gleaflet/client/Crs.java
@@ -34,6 +34,15 @@ public class Crs extends JavaScriptObject {
 		return $wnd.L.CRS[name];
 	}-*/;
 
+	/**
+	 * Adds a new Crs definition and makes it immediately available for use inside a Map. The
+	 * new Crs extends Crs.Simple, uses the Projection as specified in the parameters and
+	 * an affine transform as specified by the a, b, c, d parameters). For the meaning of the
+	 * affine transform parameters, see: http://leafletjs.com/reference.html#transformation.
+	 * @param name Name for the new Crs.
+	 * @param projection Name of the projection for this new Crs. It needs to be the name of a
+	 * valid projection defined in L.Projection (LonLat, SphericalMercator, Mercator).
+	 */
 	public static native final Crs add(String name, String projection, double a, double b, double c, double d)
 	/*-{
             $wnd.L.CRS[name] = $wnd.L.extend({}, $wnd.L.CRS.Simple, {


### PR DESCRIPTION
Hi. This change is for the definition of new CRS to be used in a Map.

One can use existing CRS with Crs.byName() and define and use new CRS with Crs.add().