### PR TITLE
Custom Crs should extend L.CRS, not L.CRS.Simple.

### DIFF
--- a/src/main/java/org/peimari/gleaflet/client/Crs.java
+++ b/src/main/java/org/peimari/gleaflet/client/Crs.java
@@ -45,7 +45,7 @@ public class Crs extends JavaScriptObject {
 	 */
 	public static native final Crs add(String name, String projection, double a, double b, double c, double d)
 	/*-{
-            $wnd.L.CRS[name] = $wnd.L.extend({}, $wnd.L.CRS.Simple, {
+            $wnd.L.CRS[name] = $wnd.L.extend({}, $wnd.L.CRS, {
                 code: name,
 		projection: $wnd.L.Projection[projection],
                 transformation: new $wnd.L.Transformation(a, b, c, d)


### PR DESCRIPTION
In this way, client code can safely ignore the size of the tiles when creating custom Crs.