### PR TITLE
Fix default marker path

### DIFF
--- a/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
+++ b/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
@@ -25,7 +25,7 @@ public class LeafletResourceInjector {
 	}
 
 	protected String getDefaultMarkerDirectory() {
-		return GWT.getModuleBaseURL() + "markers";
+		return GWT.getModuleBaseURL() + "markers/";
 	}
 
 	protected native static void setDefaultMarkerIconPath(String path) 


### PR DESCRIPTION
L.Icon.Default.imagePath needs the path to end with a slash '/'.