### PR TITLE
#65 Simple implementation to allow using an authorization token with WmsLayer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   
     <organization>
         <name>Vaadin Community</name>
-        <url>http://vaadin.com/forum/</url>
+        <url>https://vaadin.com/forum/</url>
     </organization>
 
     <dependencies>

--- a/src/main/java/org/peimari/gleaflet/client/WmsLayer.java
+++ b/src/main/java/org/peimari/gleaflet/client/WmsLayer.java
@@ -9,5 +9,25 @@ public class WmsLayer extends TileLayer {
 	/*-{
 		return new $wnd.L.TileLayer.WMS(url, options);
 	}-*/;
+	
+	public static native WmsLayer create(String url, String authorization, String layers, WmsLayerOptions options, Map map)
+	/*-{
+	 	try {
+		    return $wnd.L.TileLayer.wmsHeader(url,
+		       {
+		          layers: layers,
+		          format: 'image/png',
+		          transparent: true
+		       },
+		       [
+		          { header: 'Authorization', value: 'Bearer ' + authorization },
+		          { header: 'Content-Type', value: 'text/plain'}
+		       ],
+		       null
+		     ).addTo(map);
+	    } catch (err) {
+	    	console.error("Error while creating the wms layer with authorization: " + err.message);
+	    }
+	}-*/;
 
 }

--- a/src/main/java/org/peimari/gleaflet/client/resources/LeafletClientBundle.java
+++ b/src/main/java/org/peimari/gleaflet/client/resources/LeafletClientBundle.java
@@ -20,5 +20,8 @@ public interface LeafletClientBundle extends ClientBundle {
 
     @Source("images/layers-2x.png")
     ImageResource layers2x();
+    
+    @Source("leaflet-wms-header/index.js")
+    TextResource pluginScript();
 
 }

--- a/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
+++ b/src/main/java/org/peimari/gleaflet/client/resources/LeafletResourceInjector.java
@@ -21,6 +21,7 @@ public class LeafletResourceInjector {
 	protected void injectResources() {
 		bundle.css().ensureInjected();
 		injectScript(bundle.baseScript().getText());
+		injectScript(bundle.pluginScript().getText());
 		setDefaultMarkerIconPath(getDefaultMarkerDirectory());
 	}
 

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/LICENSE
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2018, Ticinum Aerospace Srl
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/README.md
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/README.md
@@ -1,0 +1,82 @@
+# leaflet-wms-header
+Custom headers on Leaflet TileLayer WMS.
+It's a simple plugin that allow to set custom header for WMS interface.
+
+It works with javascript and typescript without any dependencies!
+
+Based on https://github.com/Leaflet/Leaflet/issues/2091#issuecomment-302706529.
+
+### Javascript
+```sh
+$ npm install leaflet leaflet-wms-header --save
+```
+
+```html
+<!-- Assuming your project root is "../" -->
+<script src="../node_modules/leaflet/dist/leaflet.js"></script> 
+<script src="../node_modules/leaflet-wms-header/index.js"></script> 
+```
+
+```js
+
+// YOUR LEAFLET CODE
+
+var wmsLayer = L.TileLayer.wmsHeader(
+    'https://GEOSERVER_PATH/geoserver/wms?',
+    {
+        layers: 'ne:ne',
+        format: 'image/png',
+        transparent: true,
+    },
+    [
+        { header: 'Authorization', value: 'JWT ' + MYAUTHTOKEN },
+        { header: 'content-type', value: 'text/plain'},
+    ],
+    null
+).addTo(map);
+```
+
+### Typescript
+```sh
+$ npm install leaflet @types/leaflet leaflet-wms-header --save
+```
+```ts
+import * as L from 'leaflet';
+import 'leaflet-wms-header';
+
+// YOUR LEAFLET CODE
+
+let wmsLayer: L.TileLayer.WMSHeader = L.TileLayer.wmsHeader(
+    'https://GEOSERVER_PATH/geoserver/wms?',
+    {
+        layers: layers,
+        format: 'image/png',
+        transparent: true,
+    }, [
+        { header: 'Authorization', value: 'JWT ' + MYAUTHTOKEN },
+        { header: 'content-type', value: 'text/plain'},
+    ],
+    null
+).addTo(map);
+```
+
+### Abort parameter
+
+Abort parameter allow to abort the http request through an Observable. This optimization function might be usefull to stop the http request when it is not necessary anymore, mostly if many requests are pending. An example is provided on /tests/system-tests.html .
+
+See below an example using an Observable as "abort" parameter.
+
+```ts
+let tileLayer: L.TileLayer.WMSHeader = L.TileLayer.wmsHeader(
+    'https://GEOSERVER_PATH/geoserver/wms?',
+    {
+        layers: layers,
+        format: 'image/png',
+        transparent: true,
+    }, [
+        { header: 'Authorization', value: 'JWT ' + MYAUTHTOKEN },
+        { header: 'content-type', value: 'text/plain'},
+    ],
+    this.abortWMSObservable$.pipe(take(1))
+);
+```

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.d.ts
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.d.ts
@@ -1,0 +1,21 @@
+import * as L from 'leaflet';
+import {Observable} from 'rxjs';
+
+declare module 'leaflet' {
+  namespace TileLayer {
+    export class WMSHeader extends WMS {
+      constructor(
+        baseUrl: string,
+        options: WMSOptions,
+        header: { header: string; value: string }[],
+        abort?: Observable<any>
+      );
+    }
+    export function wmsHeader(
+      baseUrl: string,
+      options: WMSOptions,
+      header: { header: string; value: string }[],
+      abort?: Observable<any>
+    ): L.TileLayer.WMSHeader;
+  }
+}

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.js
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.js
@@ -1,0 +1,43 @@
+/**
+ * Minified by jsDelivr using Terser v5.7.1.
+ * Original file: /npm/leaflet-wms-header@1.0.13/index.js
+ *
+ * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
+ */
+"use strict";
+async function fetchImage(e, t, r, s) {
+    let a = {};
+    r && r.forEach((e => {
+        a[e.header] = e.value
+    }));
+    const i = new AbortController,
+        l = i.signal;
+    s && s.subscribe((() => {
+        i.abort()
+    }));
+    const n = await fetch(e, {
+        method: "GET",
+        headers: a,
+        mode: "cors",
+        signal: l
+    });
+    t(await n.blob())
+}
+L.TileLayer.WMSHeader = L.TileLayer.WMS.extend({
+    initialize: function(e, t, r, s, a) {
+        L.TileLayer.WMS.prototype.initialize.call(this, e, t), this.headers = r, this.abort = s, this.results = a
+    },
+    createTile(e, t) {
+        const r = this.getTileUrl(e),
+            s = document.createElement("img");
+        return s.setAttribute("role", "presentation"), self = this, fetchImage(r, (e => {
+            const r = new FileReader;
+            r.onload = () => {
+                s.src = r.result, self.results && self.results.next(r.result)
+            }, r.readAsDataURL(e), t(null, s)
+        }), this.headers, this.abort), s
+    }
+}), L.TileLayer.wmsHeader = function(e, t, r, s, a) {
+    return new L.TileLayer.WMSHeader(e, t, r, s, a)
+};
+//# sourceMappingURL=/sm/1ac961a4038fd182ad8aa1661a360abd3483e38f4b86b525cb00eb032a619973.map

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.js_old
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/index.js_old
@@ -1,0 +1,101 @@
+//'use strict';
+
+import * as Util from "leaflet/src/core/Util";
+import * as DomUtil from "leaflet/src/dom/DomUtil";
+
+async function fetchImage(url, callback, headers, abort, requests) {
+  console.log("Inside leaflet-wms-header index.js fetchImage function..");
+  let _headers = {};
+  if (headers) {
+    headers.forEach(h => {
+      _headers[h.header] = h.value;
+    });
+  }
+  const controller = new AbortController();
+  const signal = controller.signal;
+  if (abort) {
+    abort.subscribe(() => {
+      controller.abort();
+    });
+  }
+
+  const request = {
+    url,
+    controller
+  };
+  requests.push(request);
+
+  fetch(url, {
+    method: "GET",
+    headers: _headers,
+    mode: "cors",
+    signal: signal
+  }).then(async f => {
+    const blob = await f.blob();
+    callback(blob);
+  });
+}
+
+L.TileLayer.WMSHeader = L.TileLayer.WMS.extend({
+  initialize: function (url, options, headers, abort) {
+	try {
+		console.log("Inside leaflet-wms-header index.js WMSHeader function..");
+		L.TileLayer.WMS.prototype.initialize.call(this, url, options);
+		this.headers = headers;
+		this.abort = abort;
+		this.requests = [];
+	} catch (err) {
+	    console.error("Error while initializing the wms layer in index.js: " + err.message);
+	}
+  },
+  createTile(coords, done) {
+	console.log("Inside leaflet-wms-header index.js createTile function..");
+    const url = this.getTileUrl(coords);
+    const img = document.createElement("img");
+    img.setAttribute("role", "presentation");
+    img.setAttribute("data-url", url);
+
+    fetchImage(
+      url,
+      resp => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          img.src = reader.result;
+        };
+        reader.readAsDataURL(resp);
+        done(null, img);
+      },
+      this.headers,
+      this.abort,
+      this.requests
+    );
+    return img;
+  },
+  _abortLoading: function() {
+	console.log("Inside leaflet-wms-header index.js _abortLoading function..");
+    for (const i in this._tiles) {
+      if (this._tiles[i].coords.z !== this._tileZoom) {
+        const tile = this._tiles[i].el;
+
+        tile.onload = Util.falseFn;
+        tile.onerror = Util.falseFn;
+
+        const url = tile.getAttribute("data-url");
+        const j = this.requests.findIndex(r => r && r.url === url);
+        if (j >= 0) {
+          this.requests[j].controller.abort();
+
+          tile.src = Util.emptyImageUrl;
+          DomUtil.remove(tile);
+          delete this._tiles[i];
+          delete this.requests[j];
+        }
+      }
+    }
+  }
+});
+
+L.TileLayer.wmsHeader = function (url, options, headers, abort) {
+	console.log("Inside leaflet-wms-header index.js wmsHeader function..");
+  return new L.TileLayer.WMSHeader(url, options, headers, abort);
+};

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/package.json
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "leaflet-wms-header",
+  "version": "1.0.9",
+  "description": "Custom headers on Leaflet TileLayer WMS",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ticinum-aerospace/leaflet-wms-header"
+  },
+  "keywords": [
+    "leaflet",
+    "headers",
+    "tilelayer",
+    "wms",
+    "plugin",
+    "typescript",
+    "types"
+  ],
+  "author": "Ticinum Aerospace",
+  "license": "ISC",
+  "peerDependencies": {
+    "leaflet": "^1.7.1"
+  },
+  "dependencies": {
+    "rxjs": "^6.5.3",
+    "typescript": "^2.9.2"
+  }
+}

--- a/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/tests/system-tests.html
+++ b/src/main/resources/org/peimari/gleaflet/client/resources/leaflet-wms-header/tests/system-tests.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"/>
+    <style>
+      #mapid { height: 800px; }
+    </style>
+  </head>
+  <body>
+    <div id="mapid"></div>
+    <button id="abort">Abort</button>
+    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/2.5.3/rx.all.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs-dom/7.0.3/rx.dom.min.js"></script>
+    <script src="../index.js"></script>
+    <script>
+      var mymap = L.map('mapid').setView([51.505, -0.09], 13);
+      var abortButton = document.getElementById('abort');
+      var cl = Rx.DOM.click(abortButton)
+      L.TileLayer.wmsHeader('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+        maxZoom: 17,
+        attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+      },
+        null,
+        cl
+      ).addTo(mymap);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Simple implementation to allow using an authorization token with WmsLayer

* include leaflet-wms-header plugin (https://github.com/ticinum-aerospace/leaflet-wms-header) to the client bundle
* updated index.js from https://cdn.jsdelivr.net/npm/leaflet-wms-header@1.0.13/index.min.js
* new API for WmsLayer allowing creation of the layer with an authorization token